### PR TITLE
Simplify osmo api functions

### DIFF
--- a/src/osmo/api_data.py
+++ b/src/osmo/api_data.py
@@ -5,31 +5,28 @@ OSMO_DATA_API_NETLOC = "api-osmosis-chain.imperator.co"
 LIMIT = 25
 
 
-def _query(netloc, uri_path, query_params, sleep_seconds=1):
-    result = _query_get(netloc, uri_path, query_params)
+def _query(uri_path, query_params={}, sleep_seconds=1):
+    result = _query_get(OSMO_DATA_API_NETLOC, uri_path, query_params)
     time.sleep(sleep_seconds)
     return result
 
 
 def get_count_txs(address):
-    template = "/txs/v1/tx/count/{address}"
-    uri_path = template.format(address=address)
-    query_params = {}
+    uri_path = f"/txs/v1/tx/count/{address}"
 
-    data = _query(OSMO_DATA_API_NETLOC, uri_path, query_params)
+    data = _query(uri_path)
 
     return sum(row["count"] for row in data)
 
 
 def get_txs(address, offset=0):
-    template = "/txs/v1/tx/address/{address}"
-    uri_path = template.format(address=address)
+    uri_path = f"/txs/v1/tx/address/{address}"
     query_params = {
         "limit": LIMIT,
         "offset": offset
     }
 
-    data = _query(OSMO_DATA_API_NETLOC, uri_path, query_params)
+    data = _query(uri_path, query_params)
 
     # Extract "tx_response" (found to be common data across multiple APIs)
     return [row["tx_response"] for row in data]
@@ -37,20 +34,16 @@ def get_txs(address, offset=0):
 
 def get_lp_tokens(address):
     """ Returns list of symbols """
-    template = "/lp/v1/rewards/token/{address}"
-    uri_path = template.format(address=address)
-    query_params = {}
+    uri_path = f"/lp/v1/rewards/token/{address}"
 
-    data = _query(OSMO_DATA_API_NETLOC, uri_path, query_params)
+    data = _query(uri_path)
 
     return [kv["token"] for kv in data]
 
 
 def get_lp_rewards(address, token):
-    template = "/lp/v1/rewards/historical/{address}/{token}"
-    uri_path = template.format(address=address, token=token)
-    query_params = {}
+    uri_path = f"/lp/v1/rewards/historical/{address}/{token}"
 
-    data = _query(OSMO_DATA_API_NETLOC, uri_path, query_params)
+    data = _query(uri_path)
 
     return data

--- a/src/osmo/api_historical.py
+++ b/src/osmo/api_historical.py
@@ -5,17 +5,16 @@ from osmo.api_util import _query_get
 OSMO_HISTORICAL_API_NETLOC = "api-osmosis.imperator.co"
 
 
-def _query(netloc, uri_path, query_params):
-    result = _query_get(netloc, uri_path, query_params)
+def _query(uri_path, query_params):
+    result = _query_get(OSMO_HISTORICAL_API_NETLOC, uri_path, query_params)
     time.sleep(1)
     return result
 
 
 def get_symbol(ibc_address) -> str or None:
-    template = "/search/v1/symbol"
-    uri_path = template.format()
+    uri_path = "/search/v1/symbol"
     query_params = {"denom": quote(ibc_address)}
 
-    data = _query(OSMO_HISTORICAL_API_NETLOC, uri_path, query_params)
+    data = _query(uri_path, query_params)
 
     return data["symbol"] if "symbol" in data else None

--- a/src/osmo/api_tx.py
+++ b/src/osmo/api_tx.py
@@ -4,17 +4,15 @@ from osmo.api_util import _query_get
 OSMO_TX_API_NETLOC = "api-osmosis.cosmostation.io"
 
 
-def _query(netloc, uri_path, query_params):
-    result = _query_get(netloc, uri_path, query_params)
+def _query(uri_path, query_params={}):
+    result = _query_get(OSMO_TX_API_NETLOC, uri_path, query_params)
     time.sleep(1)
     return result
 
 
 def get_tx(txid):
-    template = "/v1/tx/hash/{txid}"
-    uri_path = template.format(txid=txid)
-    query_params = {}
+    uri_path = f"/v1/tx/hash/{txid}"
 
-    data = _query(OSMO_TX_API_NETLOC, uri_path, query_params)
+    data = _query(uri_path)
 
     return data["data"]


### PR DESCRIPTION
- use template strings instead of string.format
- move netloc into helper _query functions
- make query params have an empty default