### PR TITLE
Use a single session for API requests

### DIFF
--- a/src/common/ibc/api_lcd.py
+++ b/src/common/ibc/api_lcd.py
@@ -13,6 +13,7 @@ EVENTS_TYPE_RECIPIENT = "recipient"
 
 
 class LcdAPI:
+    session = requests.Session()
 
     def __init__(self, node):
         self.node = node
@@ -21,7 +22,7 @@ class LcdAPI:
     def _query(self, uri_path, query_params, sleep_seconds=0):
         url = f"{self.node}{uri_path}"
         logging.info("Requesting url %s?%s ...", url, urlencode(query_params))
-        response = requests.get(url, query_params)
+        response = self.session.get(url, query_params)
 
         if sleep_seconds:
             time.sleep(sleep_seconds)

--- a/src/common/ibc/api_rpc.py
+++ b/src/common/ibc/api_rpc.py
@@ -10,6 +10,7 @@ from settings_csv import REPORTS_DIR
 
 
 class RpcAPI:
+    session = requests.Session()
 
     def __init__(self, node):
         self.node = node
@@ -18,7 +19,7 @@ class RpcAPI:
     def _query(self, uri_path, query_params, sleep_seconds=0):
         url = f"{self.node}{uri_path}"
         logging.info("Requesting url %s?%s ...", url, urlencode(query_params))
-        response = requests.get(url, query_params)
+        response = self.session.get(url, query_params)
 
         if sleep_seconds:
             time.sleep(sleep_seconds)

--- a/src/osmo/api_data.py
+++ b/src/osmo/api_data.py
@@ -1,13 +1,13 @@
 import time
 
-from osmo.api_util import _query_get
+from osmo.api_util import APIUtil
 
 OSMO_DATA_API_NETLOC = "api-osmosis-chain.imperator.co"
 LIMIT_PER_QUERY = 25
 
 
 def _query(uri_path, query_params, sleep_seconds=1):
-    result = _query_get(OSMO_DATA_API_NETLOC, uri_path, query_params)
+    result = APIUtil.query_get(OSMO_DATA_API_NETLOC, uri_path, query_params)
     time.sleep(sleep_seconds)
     return result
 

--- a/src/osmo/api_historical.py
+++ b/src/osmo/api_historical.py
@@ -1,13 +1,13 @@
 import time
 from urllib.parse import quote
 
-from osmo.api_util import _query_get
+from osmo.api_util import APIUtil
 
 OSMO_HISTORICAL_API_NETLOC = "api-osmosis.imperator.co"
 
 
 def _query(uri_path, query_params):
-    result = _query_get(OSMO_HISTORICAL_API_NETLOC, uri_path, query_params)
+    result = APIUtil.query_get(OSMO_HISTORICAL_API_NETLOC, uri_path, query_params)
     time.sleep(1)
     return result
 

--- a/src/osmo/api_tx.py
+++ b/src/osmo/api_tx.py
@@ -1,12 +1,12 @@
 import time
 
-from osmo.api_util import _query_get
+from osmo.api_util import APIUtil
 
 OSMO_TX_API_NETLOC = "api-osmosis.cosmostation.io"
 
 
 def _query(uri_path, query_params):
-    result = _query_get(OSMO_TX_API_NETLOC, uri_path, query_params)
+    result = APIUtil.query_get(OSMO_TX_API_NETLOC, uri_path, query_params)
     time.sleep(1)
     return result
 

--- a/src/osmo/api_util.py
+++ b/src/osmo/api_util.py
@@ -6,17 +6,21 @@ import requests
 SCHEME = "https"
 
 
-def _query_get(netloc, uri_path, query_params):
-    url = urlunparse((
-        SCHEME,
-        netloc,
-        uri_path,
-        None,
-        urlencode(query_params),
-        None,
-    ))
+class APIUtil:
+    session = requests.Session()
 
-    logging.info("Querying url=%s...", url)
-    response = requests.get(url)
+    @classmethod
+    def query_get(cls, netloc, uri_path, query_params):
+        url = urlunparse((
+            SCHEME,
+            netloc,
+            uri_path,
+            None,
+            urlencode(query_params),
+            None,
+        ))
 
-    return response.json()
+        logging.info("Querying url=%s...", url)
+        response = cls.session.get(url)
+
+        return response.json()

--- a/src/sol/api_rpc.py
+++ b/src/sol/api_rpc.py
@@ -11,6 +11,7 @@ TOKEN_ACCOUNTS = {}
 
 
 class RpcAPI(object):
+    session = requests.Session()
 
     @classmethod
     def _fetch(cls, method, params_list):
@@ -24,14 +25,14 @@ class RpcAPI(object):
         headers = {}
 
         try:
-            response = requests.post(SOL_NODE, json=data, headers=headers)
+            response = cls.session.post(SOL_NODE, json=data, headers=headers)
 
         except TimeoutError:
             # quicknode server sometimes refuses connection after hundreds of requests
             s = random.randint(60, 180)
             logging.warning("Returned timeout.  Sleeping %s seconds and retrying once...", s)
             time.sleep(s)
-            response = requests.post(SOL_NODE, json=data, headers=headers)
+            response = cls.session.post(SOL_NODE, json=data, headers=headers)
 
         result = response.json()
 

--- a/src/terra/api_fcd.py
+++ b/src/terra/api_fcd.py
@@ -8,6 +8,7 @@ LIMIT_FCD = 100
 
 
 class FcdAPI:
+    session = requests.Session()
 
     @classmethod
     def get_tx(cls, txhash):
@@ -31,7 +32,7 @@ class FcdAPI:
     @classmethod
     def _query(cls, url):
         logging.info("Querying FCD url=%s...", url)
-        response = requests.get(url)
+        response = cls.session.get(url)
         data = response.json()
         time.sleep(5)
         return data

--- a/src/terra/api_lcd.py
+++ b/src/terra/api_lcd.py
@@ -12,20 +12,21 @@ import requests
 from settings_csv import TERRA_LCD_NODE
 
 
-def _query(uri_path, query_params, sleep_seconds=1):
-    url = f"{TERRA_LCD_NODE}{uri_path}"
-    logging.info("Requesting url %s?%s", url, urlencode(query_params))
-    response = requests.get(url, query_params)
-
-    time.sleep(sleep_seconds)
-    return response.json()
-
-
 class LcdAPI:
+    session = requests.Session()
 
     @classmethod
     def contract_info(cls, contract):
         uri = "/wasm/contracts/{}".format(contract)
         logging.info("Querying lcd for contract = %s ...", contract)
-        data = _query(uri, {})
+        data = cls._query(uri, {})
         return data
+
+    @classmethod
+    def _query(cls, uri_path, query_params, sleep_seconds=1):
+        url = f"{TERRA_LCD_NODE}{uri_path}"
+        logging.info("Requesting url %s?%s", url, urlencode(query_params))
+        response = cls.session.get(url, query_params)
+
+        time.sleep(sleep_seconds)
+        return response.json()

--- a/src/terra/api_search_figment.py
+++ b/src/terra/api_search_figment.py
@@ -9,6 +9,7 @@ LIMIT_FIGMENT = 1000
 
 
 class SearchAPIFigment:
+    session = requests.Session()
 
     @classmethod
     def get_txs(cls, address, offset=None, limit=None):
@@ -24,7 +25,7 @@ class SearchAPIFigment:
         if offset:
             data["offset"] = offset
 
-        response = requests.post(url, json=data)
+        response = cls.session.post(url, json=data)
         response_data = response.json()
 
         time.sleep(0.2)


### PR DESCRIPTION
Use a single session for API requests to avoid excessive connections. Where possible I've used the Borg pattern to simplify things, otherwise the Singleton class is used.

I've tested the changes on some blockchains. I believe you have a good test coverage for all these blockchains, can you please double check and run the tests to make sure I didn't break anything?