### PR TITLE
update cointracking remap for ATOM

### DIFF
--- a/src/common/Exporter.py
+++ b/src/common/Exporter.py
@@ -1040,6 +1040,7 @@ class Exporter:
         remap = {
             "ANC": "ANC2",
             "ASTRO": "ASTRO5",
+            "ATOM": "ATOM2",
             "GLOW": "GLOW3",
             "BETH": "BETH3",
             "LUNA": "LUNA2",


### PR DESCRIPTION
in cointracking ATOM Is ATOM2
![image](https://user-images.githubusercontent.com/8913482/158680691-dc71ea88-367a-4fef-9d08-475e9950dbb9.png)
