### PR TITLE
Add terraswap route swap support (for bPSI-DP-24m)

### DIFF
--- a/src/terra/col5/contracts/terraswap_route_swap.py
+++ b/src/terra/col5/contracts/terraswap_route_swap.py
@@ -1,0 +1,41 @@
+
+from terra.col5.contracts.config import CONTRACTS
+from terra import util_terra
+from terra.make_tx import make_swap_tx_terra
+
+def _extract_asset_info_contract_or_denom(asset_info):
+    if 'native_token' in asset_info:
+        return asset_info['native_token']['denom']
+
+    return asset_info['token']['contract_addr']
+
+def handle_terraswap_route_swap(elem, txinfo):
+
+    txid = txinfo.txid
+    COMMENT = "terraswap route swap"
+
+    for msg in txinfo.msgs:
+        execute_swap_operations = msg.execute_msg['execute_swap_operations']
+
+        offer_amount =execute_swap_operations['offer_amount']
+        offer_asset_info = execute_swap_operations['operations'][0]
+        offer_currency = util_terra._asset_to_currency(_extract_asset_info_contract_or_denom(offer_asset_info['terra_swap']['offer_asset_info']), txid)
+        receive_info = execute_swap_operations['operations'][-1]
+        receive_amount = util_terra._event_from_log(elem, 'from_contract')['return_amount'][-1]
+        receive_currency = util_terra._asset_to_currency(_extract_asset_info_contract_or_denom(receive_info['terra_swap']['ask_asset_info']), txid)
+        row = make_swap_tx_terra(
+            txinfo,
+            util_terra._float_amount(offer_amount, offer_currency),
+            offer_currency,
+            util_terra._float_amount(receive_amount, receive_currency),
+            receive_currency,
+            txid=txid,
+            empty_fee=False
+        )
+        row.comment = COMMENT
+
+        return [row]
+
+
+# Terraswap Route Swap
+CONTRACTS["terra19qx5xe6q9ll4w0890ux7lv2p4mf3csd4qvt3ex"] = handle_terraswap_route_swap

--- a/src/terra/col5/handle.py
+++ b/src/terra/col5/handle.py
@@ -3,6 +3,7 @@ from common.make_tx import make_spend_tx
 from terra.col5.contracts.config import CONTRACTS
 import terra.col5.contracts.astroport
 import terra.col5.contracts.wormhole
+import terra.col5.contracts.terraswap_route_swap
 
 
 

--- a/src/terra/util_terra.py
+++ b/src/terra/util_terra.py
@@ -426,6 +426,14 @@ def _events_with_action(elem, event_type, action):
                 events.append(event)
     return events
 
+def _event_from_log(elem, event_type):
+    logs = elem["logs"]
+    for log in logs:
+        event = log["events_by_type"].get(event_type, None)
+        if event:
+            return event
+
+    return None
 
 def _ingest_rows(exporter, rows, comment=None):
     for i, row in enumerate(rows):

--- a/src/terra/util_terra.py
+++ b/src/terra/util_terra.py
@@ -316,6 +316,19 @@ def _lookup_address(addr, txid):
     elif "terraswap_factory" in init_msg:
         localconfig.currency_addresses[addr] = None
         return None
+    elif "pool" in init_msg:
+        pool_addr = init_msg["pool"]
+
+        if pool_addr == "terra1fmnedmd3732gwyyj47r5p03055mygce98dpte2":
+            currency = 'bPSI-DP-24m'
+            decimals = 6
+            localconfig.currency_addresses[addr] = currency
+            localconfig.decimals[currency] = decimals
+
+            logging.info("Found symbol=%s decimals=%s", currency, decimals)
+            return currency
+        else:
+            raise Exception("Unable to determine currency/swap pair for addr=%s, txid=%s", addr, txid)
     else:
         localconfig.currency_addresses[addr] = ""
         raise Exception("Unable to determine currency/swap pair for addr=%s, txid=%s", addr, txid)


### PR DESCRIPTION
# This PR will:

- Add terraswap route swap support, initially with focus on supporting bPSI-DP-24M trades
- Add "events from log" helper to extract events from log messages
   
## testing

Two random transactions picked up from the route-swap contract:
- https://finder.extraterrestrial.money/mainnet/tx/DB5A846ABE56585EF99906108C4251F508FCCDDCD15629D318B8AA8FF907CAE5
- https://finder.extraterrestrial.money/mainnet/tx/7090E0A61AFAF52D4597B853C8063FC5F33E87A215FCC7953C7D70DC83A289EE


Close #118 