### PR TITLE
Add support for the Sentinel chain (DVPN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 # staketaxcsv
 
 * Python repository to create blockchain CSVs for Algorand (ALGO), Bitsong (BTSG), Cosmos (ATOM), Chihuahua (HUAHUA), 
-  Fetch.ai (FET), IoTex (IOTX), Juno (JUNO), Osmosis (OSMO), Solana (SOL), Stargaze (STARS), and 
-  Terra (LUNA) blockchains
+  Fetch.ai (FET), IoTex (IOTX), Juno (JUNO), Osmosis (OSMO), Sentinel (DVPN), Solana (SOL),
+  Stargaze (STARS), and Terra (LUNA) blockchains
 * CSV codebase for <https://stake.tax>
 * Community contribution and PRs are most welcome, especially to fix/support new types of
   protocols/transactions.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
   
 # Usage
 
-* Same arguments apply for report_algo.py (ALGO), report_atom.py (ATOM), report_btsg.py (BTSG), report_fet.py (FET),
-  report_huahua.py (HUAHUA), report_juno.py (JUNO), report_iotex.py (IOTX), report_osmo.py (OSMO),
-  report_stars.py (STARS), report_sol.py (SOL), report_terra.py (LUNA):
+* Same arguments apply for report_algo.py (ALGO), report_atom.py (ATOM), report_btsg.py (BTSG), report_dvpn.py (DVPN),
+  report_fet.py (FET), report_huahua.py (HUAHUA), report_juno.py (JUNO), report_iotex.py (IOTX),
+  report_osmo.py (OSMO), report_stars.py (STARS), report_sol.py (SOL), report_terra.py (LUNA):
 
   ```sh
   # Load environment variables from sample.env (add to ~/.bash_profile or ~/.bashrc to avoid doing every time)

--- a/src/common/ibc/api_common.py
+++ b/src/common/ibc/api_common.py
@@ -1,0 +1,25 @@
+TXS_LIMIT_PER_QUERY = 50
+EVENTS_TYPE_SENDER = "sender"
+EVENTS_TYPE_RECIPIENT = "recipient"
+EVENTS_TYPE_SIGNER = "signer"
+EVENTS_TYPE_LIST_DEFAULT = [
+    EVENTS_TYPE_SENDER,
+    EVENTS_TYPE_RECIPIENT,
+]
+
+
+def remove_duplicates(elems, tx_hash_key="txhash", timestamp_sort=True):
+    out = []
+    txids = set()
+
+    for elem in elems:
+        if elem[tx_hash_key] in txids:
+            continue
+
+        out.append(elem)
+        txids.add(elem[tx_hash_key])
+
+    if timestamp_sort:
+        out.sort(key=lambda elem: elem["timestamp"], reverse=True)
+
+    return out

--- a/src/common/ibc/api_lcd.py
+++ b/src/common/ibc/api_lcd.py
@@ -1,21 +1,19 @@
-import json
 import logging
 import math
-import os
-import requests
 import time
 from urllib.parse import urlencode
-from settings_csv import REPORTS_DIR
-from common.debug_util import use_debug_files
 
-TXS_LIMIT_PER_QUERY = 50
-EVENTS_TYPE_SENDER = "sender"
-EVENTS_TYPE_RECIPIENT = "recipient"
-EVENTS_TYPE_SIGNER = "signer"
-EVENTS_TYPE_LIST_DEFAULT = [
-    EVENTS_TYPE_SENDER,
+import requests
+from common.debug_util import use_debug_files
+from common.ibc.api_common import (
+    EVENTS_TYPE_LIST_DEFAULT,
     EVENTS_TYPE_RECIPIENT,
-]
+    EVENTS_TYPE_SENDER,
+    EVENTS_TYPE_SIGNER,
+    TXS_LIMIT_PER_QUERY,
+    remove_duplicates,
+)
+from settings_csv import REPORTS_DIR
 
 
 class LcdAPI:
@@ -124,22 +122,7 @@ def get_txs_all(node, wallet_address, progress, max_txs, limit=TXS_LIMIT_PER_QUE
             if offset is None:
                 break
 
-    out = _remove_duplicates(out)
-    return out
-
-
-def _remove_duplicates(elems):
-    out = []
-    txids = set()
-
-    for elem in elems:
-        if elem["txhash"] in txids:
-            continue
-
-        out.append(elem)
-        txids.add(elem["txhash"])
-
-    out.sort(key=lambda elem: elem["timestamp"], reverse=True)
+    out = remove_duplicates(out)
     return out
 
 

--- a/src/common/ibc/api_rpc.py
+++ b/src/common/ibc/api_rpc.py
@@ -1,22 +1,32 @@
-
-import json
+import ast
+import base64
+import functools
 import logging
 import math
-import os
-import requests
 import time
 from urllib.parse import urlencode
-from settings_csv import REPORTS_DIR
+
+import requests
+from common.ibc.api_common import (
+    EVENTS_TYPE_LIST_DEFAULT,
+    EVENTS_TYPE_RECIPIENT,
+    EVENTS_TYPE_SENDER,
+    EVENTS_TYPE_SIGNER,
+    remove_duplicates,
+)
+from common.ibc.protobuf_decoder import CosmosTransactionFeeExtractor, ProtobufParser, ProtobufParserCallback
+from dateutil import parser
+from fet.fetchhub1.api_rpc import TXS_LIMIT_PER_QUERY
 
 
 class RpcAPI:
     session = requests.Session()
+    debug = False
 
     def __init__(self, node):
         self.node = node
-        self.debug = False
 
-    def _query(self, uri_path, query_params, sleep_seconds=0):
+    def _query(self, uri_path, query_params, sleep_seconds=0.0):
         url = f"{self.node}{uri_path}"
         logging.info("Requesting url %s?%s ...", url, urlencode(query_params))
         response = self.session.get(url, params=query_params)
@@ -25,6 +35,30 @@ class RpcAPI:
             time.sleep(sleep_seconds)
         return response.json()
 
+    def _block(self, height):
+        uri_path = "/block"
+        query_params = {"height": height}
+
+        data = self._query(uri_path, query_params, sleep_seconds=0.2)
+
+        return data
+
+    def _txs_search(self, wallet_address, events_type, page, per_page):
+        uri_path = "/tx_search"
+        query_params = {"page": page, "per_page": per_page}
+        if events_type == EVENTS_TYPE_SENDER:
+            query_params["query"] = "\"message.sender='{}'\"".format(wallet_address)
+        elif events_type == EVENTS_TYPE_RECIPIENT:
+            query_params["query"] = "\"transfer.recipient='{}'\"".format(wallet_address)
+        elif events_type == EVENTS_TYPE_SIGNER:
+            query_params["query"] = "\"message.signer='{}'\"".format(wallet_address)
+        else:
+            raise Exception("Add case for events_type: {}".format(events_type))
+
+        data = self._query(uri_path, query_params, sleep_seconds=1)
+
+        return data
+
     def get_tx(self, txid):
         uri_path = "/tx"
         query_params = {
@@ -32,3 +66,180 @@ class RpcAPI:
         }
         data = self._query(uri_path, query_params, sleep_seconds=1)
         return data.get("tx_response", None)
+
+    def txs_search(self, wallet_address, events_type, page, per_page):
+        data = self._txs_search(wallet_address, events_type, page, per_page)
+
+        elems = data["result"]["txs"]
+        total_count_txs = int(data["result"]["total_count"])
+        total_count_pages = math.ceil(total_count_txs / per_page)
+        if page >= total_count_pages:
+            next_page = None
+        else:
+            next_page = page + 1
+
+        return elems, next_page, total_count_pages, total_count_txs
+
+    @functools.lru_cache
+    def block_time(self, height):
+        data = self._block(height)
+
+        return data["result"]["block"]["header"]["time"]
+
+
+def get_txs_all(node, wallet_address, progress, max_txs, limit=TXS_LIMIT_PER_QUERY, debug=False,
+                stage_name="default", events_types=None):
+    api = RpcAPI(node)
+    api.debug = debug
+    events_types = events_types if events_types else EVENTS_TYPE_LIST_DEFAULT
+    max_pages = math.ceil(max_txs / limit)
+
+    out = []
+    page_for_progress = 1
+    for events_type in events_types:
+        for page in range(1, max_pages + 1):
+            message = f"Fetching page {page_for_progress} ..."
+            progress.report(page_for_progress, message, stage_name)
+            page_for_progress += 1
+
+            elems, next_page, _, _ = api.txs_search(wallet_address, events_type, page, limit)
+
+            out.extend(elems)
+            if next_page is None:
+                break
+
+    out = remove_duplicates(out, tx_hash_key="hash", timestamp_sort=False)
+    return out
+
+
+def get_txs_pages_count(node, address, max_txs, limit=TXS_LIMIT_PER_QUERY, debug=False,
+                        events_types=None):
+    api = RpcAPI(node)
+    api.debug = debug
+    events_types = events_types if events_types else EVENTS_TYPE_LIST_DEFAULT
+
+    total_pages = 0
+    for event_type in events_types:
+        _, _, num_pages, num_txs = api.txs_search(address, event_type, 1, limit)
+        num_txs = min(num_txs, max_txs)
+        num_pages = math.ceil(num_txs / limit) if num_txs else 1
+
+        logging.info("event_type: %s, num_txs: %s, num_pages: %s", event_type, num_txs, num_pages)
+        total_pages += num_pages
+
+    return total_pages
+
+
+def normalize_rpc_txns(node, elems):
+    """
+    Normalize the RPC transaction element to have fields a LCD transaction element
+    would have.
+    Decodes base64 encoded fields as needed.
+    """
+    for elem in elems:
+        elem = _decode(elem)
+
+        # add the txhash field
+        elem["txhash"] = elem["hash"]
+
+        # add the timestamp field
+        _add_timestamp_from_block_time(elem, node)
+
+        # add the fee
+        _add_fee_from_cosmos_transaction_authinfo(elem)
+
+        # add transaction messages
+        _add_messages_from_logs(elem)
+
+
+def _decode(elem):
+    """ Modifies transaction data with decoded version """
+    elem["tx_result"]["log"] = ast.literal_eval(elem["tx_result"]["log"])
+
+    events = elem["tx_result"]["events"]
+    for event in events:
+        for kv in event["attributes"]:
+            k, v = kv["key"], kv["value"]
+
+            kv["key"] = base64.b64decode(k).decode()
+            kv["value"] = base64.b64decode(v).decode()
+
+    elem["tx"] = base64.b64decode(elem["tx"])
+
+    return elem
+
+
+def _add_timestamp_from_block_time(elem, node):
+    """
+    Add a timestamp field to an RPC element.
+    """
+    # since there isn't a timestamp on the RPC transaction data, we
+    # need to get the timestamp based on the block processing time
+    # it's also converted from the RPC format to the LCD format:
+    #     i.e. "2021-08-26T21:08:44.86954814Z" -> "2021-08-26T21:08:44Z"
+    height = elem["height"]
+    block_timestamp = RpcAPI(node).block_time(height)
+    block_timestamp = parser.parse(block_timestamp).strftime("%Y-%m-%dT%H:%M:%SZ")
+    elem["timestamp"] = block_timestamp
+
+
+def _add_fee_from_cosmos_transaction_authinfo(elem):
+    """
+    Extracts the fee denom and amount from the protobuf encoded cosmos transaction data and
+    adds it to the RPC element.
+    """
+    fee_extractor_callback = CosmosTransactionFeeExtractor()
+    protobuf_parser = ProtobufParser(elem["tx"], fee_extractor_callback)
+    protobuf_parser.parse()
+
+    elem["tx"] = {
+        "auth_info": {
+            "fee": {
+                "amount": [
+                    {
+                        "denom": fee_extractor_callback.fee_denom,
+                        "amount": fee_extractor_callback.fee_amount
+                    }
+                ]
+            }
+        }
+    }
+
+
+def _add_messages_from_logs(elem):
+
+    messages = []
+
+    logs = elem["tx_result"]["log"]
+    elem["logs"] = logs
+    for log in logs:
+        for event in log["events"]:
+            event_type = event["type"]
+            event_attributes = event["attributes"]
+
+            if event_type != "message":
+                continue
+
+            message = _make_message_from_event_attributes(event_attributes)
+            messages.append(message)
+
+    # add messages into the transaction body element
+    elem["tx"]["body"] = {
+        "messages": messages
+    }
+
+
+def _make_message_from_event_attributes(event_attributes):
+    message = {}
+    for kv in event_attributes:
+        key, value = kv["key"], kv["value"]
+        message[key] = value
+
+    # set the message type field that LCD responses provide
+    #
+    # note: we do not do any other combination of events to produce application
+    # specific message fields and rely on transfer events to dictate any movement of coins
+    message["@type"] = message["action"]
+    del message["action"]
+
+    return message

--- a/src/common/ibc/protobuf_decoder.py
+++ b/src/common/ibc/protobuf_decoder.py
@@ -16,7 +16,6 @@ class Varint:
     def __init__(self):
         self._varint = 0
         self._shift = 0
-        self._bytes_read = 0
 
     @property
     def byte_size(self) -> int:

--- a/src/common/ibc/protobuf_decoder.py
+++ b/src/common/ibc/protobuf_decoder.py
@@ -178,10 +178,10 @@ class CosmosTransactionFeeExtractor(ProtobufParserCallback):
 class ProtobufParser:
     """
     A protobuf parser to parse protobuf data without a .proto file.
-    Most useful to extract data when you know the .proto file the buffer is based on, but you don't want to load it
+    Most useful to extract data when you know the .proto file the data is based on, but you don't want to load it
     into an application.
 
-    Implements the encoding described here : https://developers.google.com/protocol-buffers/docs/encoding
+    Implements the encoding described here: https://developers.google.com/protocol-buffers/docs/encoding.
     """
 
     _buffer: io.BytesIO

--- a/src/common/ibc/protobuf_decoder.py
+++ b/src/common/ibc/protobuf_decoder.py
@@ -81,7 +81,7 @@ class ProtobufParserStack:
         self._stack.append(frame)
         self._clear_field_path()
 
-    def update_current_frame(self, end_of_field_offset: int):
+    def update_frame(self, end_of_field_offset: int):
         if not self._stack:
             raise RuntimeError("no stack frame to update")
 
@@ -202,7 +202,7 @@ class ProtobufParser:
             parser_stack.push_frame(field_number=field_number, end_of_field_offset=None)
             field_value, parse_embedded_message, embedded_message_length = self._get_field_value(wire_type, field_number, parser_stack)
             if parse_embedded_message:
-                parser_stack.update_current_frame(end_of_field_offset=self._buffer.tell() + embedded_message_length)
+                parser_stack.update_frame(end_of_field_offset=self._buffer.tell() + embedded_message_length)
                 continue
 
             # callback the application with any values found

--- a/src/common/ibc/protobuf_decoder.py
+++ b/src/common/ibc/protobuf_decoder.py
@@ -1,0 +1,286 @@
+import io
+import sys
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Optional, Tuple
+
+
+class Varint:
+    """
+    Constructs the integer encoded as a base 128 varint from a stream of bytes.
+    """
+    _varint: int
+    _shift: int
+
+    def __init__(self):
+        self._varint = 0
+        self._shift = 0
+        self._bytes_read = 0
+
+    @property
+    def byte_size(self) -> int:
+        return int((self._shift + (8 - (self._shift % 8))) / 8)
+
+    @property
+    def value(self):
+        return self._varint
+
+    def from_bytes(self, byte_stream: io.BytesIO) -> None:
+        while True:
+            byte = byte_stream.read(1)
+            if byte == b"":
+                raise EOFError("unexpected end of byte sequence while parsing varint")
+
+            # single byte, so byte order doesn't matter
+            byte = int.from_bytes(byte, sys.byteorder)
+
+            # add this byte's data into the varint
+            self._varint |= (byte & 0x7f) << self._shift
+            self._shift += 7
+
+            # if the most significant bit is set, there is another byte to read for this varint
+            if not byte & 0x80:
+                break
+
+
+class ProtobufWireType(Enum):
+    VARINT = 0
+    FIXED_64_BIT = 1
+    LENGTH_DELIMITED = 2
+    FIXED_32_BIT = 5
+
+    # start group and end group wire types are deprecated and not supported
+    START_GROUP = 3
+    END_GROUP = 4
+
+
+@dataclass
+class ProtobufParserFrame:
+    field_number: int
+    end_of_field_offset: Optional[int]
+
+
+class ProtobufParserStack:
+
+    _stack: List[ProtobufParserFrame]
+    _field_path: str
+
+    def __init__(self):
+        self._stack = []
+        self._field_path = ""
+
+    @property
+    def field_path(self) -> str:
+        if not self._field_path:
+            self._make_field_path()
+
+        return self._field_path
+
+    def push_frame(self, field_number: int, end_of_field_offset: Optional[int]) -> None:
+        frame = ProtobufParserFrame(field_number=field_number, end_of_field_offset=end_of_field_offset)
+        self._stack.append(frame)
+        self._clear_field_path()
+
+    def update_current_frame(self, end_of_field_offset: int):
+        if not self._stack:
+            raise RuntimeError("no stack frame to update")
+
+        self._stack[-1].end_of_field_offset = end_of_field_offset
+
+    def peek_frame(self) -> Optional[ProtobufParserFrame]:
+        if not self._stack:
+            return None
+
+        return self._stack[-1]
+
+    def pop_frame(self) -> ProtobufParserFrame:
+        self._clear_field_path()
+        return self._stack.pop()
+
+    def _make_field_path(self) -> None:
+        self._field_path = ":".join([str(frame.field_number) for frame in self._stack])
+
+    def _clear_field_path(self) -> None:
+        self._field_path = ""
+
+
+class ProtobufParserMessageAction(Enum):
+    SKIP = 0
+    PARSE_AS_MESSAGE = 1
+    PARSE_AS_BYTES = 2
+
+
+class ProtobufParserCallback(ABC):
+
+    @abstractmethod
+    def on_length_delimited_field(self, field_number: int, field_path: str) -> ProtobufParserMessageAction:
+        """
+        Callback function to tell the protobuf parser how to act when it finds a
+        length delimited field.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def on_field(self, wire_type: ProtobufWireType, field_number: int, field_value: bytes, field_path: str) -> None:
+        """
+        Callback function when a new field that isn't a message is found.
+        The value is passed as bytes and up to the user to determine how to decode it.
+        The field_path is a colon delimited string of the field numbers this field is a child of.
+        """
+        raise NotImplementedError()
+
+
+class CosmosTransactionFeeExtractor(ProtobufParserCallback):
+    """
+    A protobuf parser callback that extracts the fee for a transaction from the AuthInfo message object of the protobuf
+    structure defined here: https://github.com/cosmos/cosmos-sdk/blob/main/proto/cosmos/tx/v1beta1/tx.proto.
+    """
+
+    coin_message_base_path: str = "2:2:1"
+    coin_denom_path: str = f"{coin_message_base_path}:1"
+    coin_amount_path: str = f"{coin_message_base_path}:2"
+
+    _fee_denom: Optional[str]
+    _fee_amount: Optional[str]
+
+    def __init__(self):
+        self._fee_denom = None
+        self._fee_amount = None
+
+    @property
+    def fee_denom(self) -> Optional[str]:
+        return self._fee_denom
+
+    @property
+    def fee_amount(self) -> Optional[str]:
+        return self._fee_amount
+
+    def on_length_delimited_field(self, field_number: int, field_path: str) -> ProtobufParserMessageAction:
+        if not field_path:
+            raise RuntimeError(f"unexpected empty field path while processing protobuf data")
+
+        if field_path in (self.coin_denom_path, self.coin_amount_path):
+            return ProtobufParserMessageAction.PARSE_AS_BYTES
+
+        if self.coin_message_base_path.startswith(field_path):
+            return ProtobufParserMessageAction.PARSE_AS_MESSAGE
+
+        return ProtobufParserMessageAction.SKIP
+
+    def on_field(self, wire_type: ProtobufWireType, field_number: int, field_value: bytes, field_path: str) -> None:
+        if field_path == self.coin_denom_path:
+            self._fee_denom = field_value.decode("utf-8")
+        elif field_path == self.coin_amount_path:
+            self._fee_amount = field_value.decode("utf-8")
+
+
+class ProtobufParser:
+    """
+    A protobuf parser to parse protobuf data without a .proto file.
+    Most useful to extract data when you know the .proto file the buffer is based on, but you don't want to load it
+    into an application.
+
+    Implements the encoding described here : https://developers.google.com/protocol-buffers/docs/encoding
+    """
+
+    _buffer: io.BytesIO
+    _buffer_size: int
+    _callback: ProtobufParserCallback
+
+    def __init__(self, protobuf_bytes: bytes, callback: ProtobufParserCallback):
+        self._buffer = io.BytesIO(protobuf_bytes)
+        self._buffer_size = len(protobuf_bytes)
+        self._callback = callback
+
+    def parse(self):
+        parser_stack: ProtobufParserStack = ProtobufParserStack()
+        while self._buffer.tell() < self._buffer_size:
+            # get the next field key
+            wire_type, field_number = self._get_field_key()
+
+            # handle wire types
+            parser_stack.push_frame(field_number=field_number, end_of_field_offset=None)
+            field_value, parse_embedded_message, embedded_message_length = self._get_field_value(wire_type, field_number, parser_stack)
+            if parse_embedded_message:
+                parser_stack.update_current_frame(end_of_field_offset=self._buffer.tell() + embedded_message_length)
+                continue
+
+            # callback the application with any values found
+            if field_value is not None:
+                self._callback.on_field(wire_type, field_number, field_value, parser_stack.field_path)
+
+            # cleanup
+            parser_stack.pop_frame()
+            while frame := parser_stack.peek_frame():
+                if frame.end_of_field_offset != self._buffer.tell():
+                    break
+
+                parser_stack.pop_frame()
+
+    def _get_field_key(self) -> Tuple[ProtobufWireType, int]:
+        field_key = self._read_varint().value
+
+        wire_type = field_key & 0x07
+        field_number = field_key >> 3
+
+        return ProtobufWireType(wire_type), field_number
+
+    def _get_field_value(self, wire_type: ProtobufWireType, field_number: int, parser_stack: ProtobufParserStack) -> Tuple[Optional[bytes], bool, int]:
+        if wire_type == ProtobufWireType.START_GROUP or wire_type == ProtobufWireType.END_GROUP:
+            raise NotImplementedError("The start and end group wire types are deprecated and not supported")
+
+        parse_embedded_message = False
+        embedded_message_length = None
+
+        if wire_type == ProtobufWireType.VARINT:
+            field_value = self._parse_varint_value()
+        elif wire_type == ProtobufWireType.FIXED_64_BIT:
+            field_value = self._parse_fixed_64_bit_value()
+        elif wire_type == ProtobufWireType.LENGTH_DELIMITED:
+            field_value, parse_embedded_message, embedded_message_length = self._parse_length_delimited_value(field_number, parser_stack)
+        elif wire_type == ProtobufWireType.FIXED_32_BIT:
+            field_value = self._parse_fixed_32_bit_value()
+        else:
+            raise RuntimeError(f"Unknown wire type found [{wire_type}")
+
+        return field_value, parse_embedded_message, embedded_message_length
+
+    def _parse_varint_value(self) -> bytes:
+        varint = self._read_varint()
+        return varint.value.to_bytes(varint.byte_size, "little")
+
+    def _parse_length_delimited_value(self, field_number: int, parser_stack: ProtobufParserStack) -> Tuple[Optional[bytes], bool, int]:
+        # get the length
+        field_value_length = self._read_varint().value
+
+        # see what the user wants us to do
+        action = self._callback.on_length_delimited_field(field_number, parser_stack.field_path)
+
+        # see if we should read the field_value
+        field_value = None
+        if action in [ProtobufParserMessageAction.SKIP, ProtobufParserMessageAction.PARSE_AS_BYTES]:
+            temp_value = self._read_bytes(field_value_length)
+            if action == ProtobufParserMessageAction.PARSE_AS_BYTES:
+                field_value = temp_value
+
+        return field_value, action == ProtobufParserMessageAction.PARSE_AS_MESSAGE, field_value_length
+
+    def _parse_fixed_64_bit_value(self) -> bytes:
+        return self._read_bytes(8)
+
+    def _parse_fixed_32_bit_value(self) -> bytes:
+        return self._read_bytes(4)
+
+    def _read_varint(self) -> Varint:
+        varint = Varint()
+        varint.from_bytes(self._buffer)
+
+        return varint
+
+    def _read_bytes(self, size: int) -> bytes:
+        bytes_read = self._buffer.read(size)
+        if bytes_read == b"":
+            raise EOFError("unexpected end of byte sequence while reading protobuf")
+
+        return bytes_read

--- a/src/common/ibc/protobuf_decoder.py
+++ b/src/common/ibc/protobuf_decoder.py
@@ -22,7 +22,7 @@ class Varint:
         return int((self._shift + (8 - (self._shift % 8))) / 8)
 
     @property
-    def value(self):
+    def value(self) -> int:
         return self._varint
 
     def from_bytes(self, byte_stream: io.BytesIO) -> None:
@@ -81,7 +81,7 @@ class ProtobufParserStack:
         self._stack.append(frame)
         self._clear_field_path()
 
-    def update_frame(self, end_of_field_offset: int):
+    def update_frame(self, end_of_field_offset: int) -> None:
         if not self._stack:
             raise RuntimeError("no stack frame to update")
 
@@ -192,7 +192,7 @@ class ProtobufParser:
         self._buffer_size = len(protobuf_bytes)
         self._callback = callback
 
-    def parse(self):
+    def parse(self) -> None:
         parser_stack: ProtobufParserStack = ProtobufParserStack()
         while self._buffer.tell() < self._buffer_size:
             # get the next field key

--- a/src/common/ibc/protobuf_decoder.py
+++ b/src/common/ibc/protobuf_decoder.py
@@ -198,7 +198,7 @@ class ProtobufParser:
             # get the next field key
             wire_type, field_number = self._get_field_key()
 
-            # handle wire types
+            # get the field value
             parser_stack.push_frame(field_number=field_number, end_of_field_offset=None)
             field_value, parse_embedded_message, embedded_message_length = self._get_field_value(wire_type, field_number, parser_stack)
             if parse_embedded_message:

--- a/src/dvpn/config_dvpn.py
+++ b/src/dvpn/config_dvpn.py
@@ -1,0 +1,6 @@
+from common.config import config
+
+
+class localconfig(config):
+
+    ibc_addresses = {}

--- a/src/dvpn/constants.py
+++ b/src/dvpn/constants.py
@@ -9,6 +9,7 @@ MSG_TYPE_DVPN_UPDATE_REQUEST = "MsgUpdateRequest"
 # dVPN client subscription messages - original
 MSG_TYPE_DVPN_SERVICE_SUBSCRIBE_TO_NODE = "MsgService/MsgSubscribeToNode"
 MSG_TYPE_DVPN_SERVICE_START = "MsgService/MsgStart"
+MSG_TYPE_DVPN_SERVICE_END = "MsgService/MsgEnd"
 
 # dVPN client subscription messages - current
 MSG_TYPE_DVPN_SUBSCRIBE_TO_NODE_REQUEST = "MsgSubscribeToNodeRequest"

--- a/src/dvpn/constants.py
+++ b/src/dvpn/constants.py
@@ -1,0 +1,16 @@
+EXCHANGE_DVPN = "sentinel_blockchain"
+MINTSCAN_LABEL_DVPN = "sentinel"
+
+# dVPN node management messages
+MSG_TYPE_DVPN_REGISTER_REQUEST = "MsgRegisterRequest"
+MSG_TYPE_DVPN_SET_STATUS_REQUEST = "MsgSetStatusRequest"
+MSG_TYPE_DVPN_UPDATE_REQUEST = "MsgUpdateRequest"
+
+# dVPN client subscription messages - original
+MSG_TYPE_DVPN_SERVICE_SUBSCRIBE_TO_NODE = "MsgService/MsgSubscribeToNode"
+MSG_TYPE_DVPN_SERVICE_START = "MsgService/MsgStart"
+
+# dVPN client subscription messages - current
+MSG_TYPE_DVPN_SUBSCRIBE_TO_NODE_REQUEST = "MsgSubscribeToNodeRequest"
+MSG_TYPE_DVPN_START_REQUEST = "MsgStartRequest"
+MSG_TYPE_DVPN_END_REQUEST = "MsgEndRequest"

--- a/src/dvpn/processor.py
+++ b/src/dvpn/processor.py
@@ -6,6 +6,25 @@ from dvpn.config_dvpn import localconfig
 from settings_csv import DVPN_LCD_NODE
 
 
+def process_usage_payments(wallet_address, exporter):
+    """
+    Uses the sentinelhub API to calculate usage payments from escrow to the node operator.
+    As this data is held off-chain, the algorithm will need to leverage sentinelhub APIs to:
+        1. Get all subscriptions for the sentnode1 address (currently, this is not indexed by the sentnode1 address and requires a brute force search across all subscriptions)
+        2. For each subscription the node has, get the current usage from the quota
+        3. Multiply the usage percentage by the price set in the subscription
+
+    Also, need to figure out what timestamp can be used with the payment.
+    Quotas, unfortunately, do not contain a timestamp.
+    Subscriptions has a timestamp corresponding to the last status update time, which might be the best we can do.
+
+    As there isn't indexing by sentinel node and only the latest data is provided by the quotas and subscription
+    APIs instead of a time series, this implementation is still TODO.
+    TODO: finish this implementation
+    """
+    pass
+
+
 def process_txs(wallet_address, elems, exporter):
     for elem in elems:
         process_tx(wallet_address, elem, exporter)
@@ -46,8 +65,10 @@ def _handle_tx(exporter, txinfo, msginfo):
                       co.MSG_TYPE_DVPN_SUBSCRIBE_TO_NODE_REQUEST, co.MSG_TYPE_DVPN_START_REQUEST, co.MSG_TYPE_DVPN_END_REQUEST]:
         # dVPN client subscription messages
         _handle_subscription_message(exporter, txinfo, msginfo)
+    else:
+        return False
 
-    return False
+    return True
 
 
 def _handle_management_message(exporter, txinfo, msginfo):

--- a/src/dvpn/processor.py
+++ b/src/dvpn/processor.py
@@ -16,7 +16,7 @@ def process_usage_payments(wallet_address, exporter):
 
     Also, need to figure out what timestamp can be used with the payment.
     Quotas, unfortunately, do not contain a timestamp.
-    Subscriptions has a timestamp corresponding to the last status update time, which might be the best we can do.
+    Subscriptions have a timestamp corresponding to the last status update time which might be the best we can do.
 
     As there isn't indexing by sentinel node and only the latest data is provided by the quotas and subscription
     APIs instead of a time series, this implementation is still TODO.

--- a/src/dvpn/processor.py
+++ b/src/dvpn/processor.py
@@ -1,0 +1,94 @@
+import common.ibc.handle
+import common.ibc.processor
+import dvpn.constants as co
+from common.make_tx import make_spend_fee_tx, make_spend_tx
+from dvpn.config_dvpn import localconfig
+from settings_csv import DVPN_LCD_NODE
+
+
+def process_txs(wallet_address, elems, exporter):
+    for elem in elems:
+        process_tx(wallet_address, elem, exporter)
+
+
+def process_tx(wallet_address, elem, exporter):
+    txinfo = common.ibc.processor.txinfo(
+        wallet_address, elem, co.MINTSCAN_LABEL_DVPN, co.EXCHANGE_DVPN, localconfig.ibc_addresses, DVPN_LCD_NODE)
+
+    for msginfo in txinfo.msgs:
+        # Handle sentinel specific messages
+        result = _handle_tx(exporter, txinfo, msginfo)
+        if result:
+            continue
+
+        # Handle common messages
+        result = common.ibc.processor.handle_message(exporter, txinfo, msginfo, localconfig.debug)
+        if result:
+            continue
+
+        # Handle unknown messages
+        common.ibc.handle.handle_unknown_detect_transfers(exporter, txinfo, msginfo)
+
+    return txinfo
+
+
+def _handle_tx(exporter, txinfo, msginfo):
+    """
+    Handles sentinel specific transactions.
+    """
+
+    msg_type = msginfo.msg_type
+    if msg_type in [co.MSG_TYPE_DVPN_REGISTER_REQUEST, co.MSG_TYPE_DVPN_SET_STATUS_REQUEST,
+                    co.MSG_TYPE_DVPN_UPDATE_REQUEST]:
+        # dVPN node management messages
+        _handle_management_message(exporter, txinfo, msginfo)
+    elif msg_type in [co.MSG_TYPE_DVPN_SERVICE_SUBSCRIBE_TO_NODE, co.MSG_TYPE_DVPN_SERVICE_START,
+                      co.MSG_TYPE_DVPN_SUBSCRIBE_TO_NODE_REQUEST, co.MSG_TYPE_DVPN_START_REQUEST, co.MSG_TYPE_DVPN_END_REQUEST]:
+        # dVPN client subscription messages
+        _handle_subscription_message(exporter, txinfo, msginfo)
+
+    return False
+
+
+def _handle_management_message(exporter, txinfo, msginfo):
+    """
+    Messages that update the status of a dVPN node on-chain which will have a fee.
+    """
+    _make_spend_fee_tx(exporter, txinfo, msginfo)
+
+
+def _handle_subscription_message(exporter, txinfo, msginfo):
+    """
+    Messages that indicate what dVPN nodes a user has subscribed to and when a dVPN session starts.
+    Pricing is maintained in message data.
+    """
+    msg_type = msginfo.msg_type
+    if msg_type in [co.MSG_TYPE_DVPN_SERVICE_SUBSCRIBE_TO_NODE, co.MSG_TYPE_DVPN_SUBSCRIBE_TO_NODE_REQUEST]:
+        _make_subscribed_to_node_tx(exporter, txinfo, msginfo)
+    else:
+        _make_spend_fee_tx(exporter, txinfo, msginfo)
+
+
+def _make_subscribed_to_node_tx(exporter, txinfo, msginfo):
+    _, transfers_out = msginfo.transfers
+    assert len(transfers_out) == 1
+
+    sent_amount, sent_currency = transfers_out[0]
+    row = make_spend_tx(txinfo, sent_amount, sent_currency)
+
+    comment = "subscribed to dVPN node"
+    dvpn_node_address = msginfo.message.get("address")
+    if dvpn_node_address:
+        comment = f"{comment}: {dvpn_node_address}"
+    row.comment = comment
+
+    exporter.ingest_row(row)
+
+
+def _make_spend_fee_tx(exporter, txinfo, msginfo):
+    row = make_spend_fee_tx(txinfo, txinfo.fee, txinfo.fee_currency)
+
+    msg_type_for_comment = msginfo.msg_type.replace("Msg", "")
+    row.comment = f"fee for {msg_type_for_comment}"
+
+    exporter.ingest_row(row)

--- a/src/dvpn/progress_dvpn.py
+++ b/src/dvpn/progress_dvpn.py
@@ -1,0 +1,16 @@
+from common.progress import Progress
+from dvpn.config_dvpn import localconfig
+
+SECONDS_PER_PAGE = 2
+
+
+class ProgressDvpn(Progress):
+
+    def __init__(self):
+        super().__init__(localconfig)
+
+    def set_lcd_estimate(self, count_pages):
+        self.add_stage("lcd", count_pages, SECONDS_PER_PAGE)
+
+    def set_rpc_estimate(self, count_pages):
+        self.add_stage("rpc", count_pages, SECONDS_PER_PAGE)

--- a/src/dvpn/progress_dvpn.py
+++ b/src/dvpn/progress_dvpn.py
@@ -1,7 +1,9 @@
 from common.progress import Progress
 from dvpn.config_dvpn import localconfig
 
-SECONDS_PER_PAGE = 2
+LCD_SECONDS_PER_PAGE = 3
+RPC_SECONDS_PER_PAGE = 2
+USAGE_PAYMENTS_SECONDS_PER_PAGE = 2
 
 
 class ProgressDvpn(Progress):
@@ -10,7 +12,10 @@ class ProgressDvpn(Progress):
         super().__init__(localconfig)
 
     def set_lcd_estimate(self, count_pages):
-        self.add_stage("lcd", count_pages, SECONDS_PER_PAGE)
+        self.add_stage("lcd", count_pages, LCD_SECONDS_PER_PAGE)
 
     def set_rpc_estimate(self, count_pages):
-        self.add_stage("rpc", count_pages, SECONDS_PER_PAGE)
+        self.add_stage("rpc", count_pages, RPC_SECONDS_PER_PAGE)
+
+    def set_usage_payment_estimate(self, count_pages):
+        self.add_stage("usage-payment", count_pages, USAGE_PAYMENTS_SECONDS_PER_PAGE)

--- a/src/fet/fetchhub1/api_rpc.py
+++ b/src/fet/fetchhub1/api_rpc.py
@@ -1,17 +1,22 @@
-from dateutil import parser
 import json
 import logging
 import math
 import os
-import requests
 import time
 from urllib.parse import urlencode
-from settings_csv import REPORTS_DIR
+
+import requests
 from common.debug_util import use_debug_files
-from fet.config_fet import localconfig
-from common.ibc.api_lcd import (
-    EVENTS_TYPE_SENDER, EVENTS_TYPE_RECIPIENT, EVENTS_TYPE_SIGNER, EVENTS_TYPE_LIST_DEFAULT
+from common.ibc.api_common import (
+    EVENTS_TYPE_LIST_DEFAULT,
+    EVENTS_TYPE_RECIPIENT,
+    EVENTS_TYPE_SENDER,
+    EVENTS_TYPE_SIGNER,
 )
+from dateutil import parser
+from fet.config_fet import localconfig
+from settings_csv import REPORTS_DIR
+
 TXS_LIMIT_PER_QUERY = 50
 
 

--- a/src/report_dvpn.py
+++ b/src/report_dvpn.py
@@ -17,7 +17,7 @@ from common.Cache import Cache
 from common.Exporter import Exporter
 from common.ExporterTypes import FORMAT_DEFAULT
 from dvpn.config_dvpn import localconfig
-from dvpn.progress_dvpn import SECONDS_PER_PAGE, ProgressDvpn
+from dvpn.progress_dvpn import ProgressDvpn
 from settings_csv import DVPN_LCD_NODE, DVPN_RPC_NODE, TICKER_DVPN
 
 
@@ -116,10 +116,10 @@ def txhistory(wallet_address, options):
     progress.report_message(f"Processing {len(elems)} transactions... ")
     dvpn.processor.process_txs(wallet_address, elems, exporter)
 
-    # Calculate payments from escrow to the dVPN node for usage
-    # These payments are kept off-chain and are calculated by looking up all subscriptions,
-    # calculating their used percentage * price, and using the date information
-    # This will not be 100% accurate on timing of payments, but I haven't found a better way yet
+    # Calculate payments from escrow to the dVPN node for bandwidth usage.
+    # These payments are kept off-chain and need to be calculated through various apis provided by sentinelhub.
+    progress.set_usage_payment_estimate(0)
+    dvpn.processor.process_usage_payments(wallet_address, exporter)
 
     if localconfig.cache:
         Cache().set_ibc_addresses(localconfig.ibc_addresses)

--- a/src/report_dvpn.py
+++ b/src/report_dvpn.py
@@ -102,7 +102,7 @@ def txhistory(wallet_address, options):
 
     elems = lcd_elems
     if missing_tx_hashes:
-        progress.report_message(f"Found {len(missing_tx_hashes)} from RPC api that were missing from the LCD api")
+        progress.report_message(f"Found {len(missing_tx_hashes)} transactions from the rpc api that were missing from the lcd api")
 
         missing_elems = list(filter(
             lambda e, hashes=missing_tx_hashes: e["hash"] in hashes,

--- a/src/report_dvpn.py
+++ b/src/report_dvpn.py
@@ -1,0 +1,132 @@
+"""
+usage: python3 report_dvpn.py <walletaddress> [--format all|cointracking|koinly|..]
+
+Prints transactions and writes CSV(s) to _reports/DVPN*.csv
+
+"""
+
+import logging
+import pprint
+
+import common.ibc.api_common
+import common.ibc.api_lcd
+import common.ibc.api_rpc
+import dvpn.processor
+from common import report_util
+from common.Cache import Cache
+from common.Exporter import Exporter
+from common.ExporterTypes import FORMAT_DEFAULT
+from dvpn.config_dvpn import localconfig
+from dvpn.progress_dvpn import SECONDS_PER_PAGE, ProgressDvpn
+from settings_csv import DVPN_LCD_NODE, DVPN_RPC_NODE, TICKER_DVPN
+
+
+def main():
+    wallet_address, export_format, txid, options = report_util.parse_args(TICKER_DVPN)
+
+    if txid:
+        _read_options(options)
+        exporter = txone(wallet_address, txid)
+        exporter.export_print()
+        if export_format != FORMAT_DEFAULT:
+            report_util.export_format_for_txid(exporter, export_format, txid)
+    else:
+        exporter = txhistory(wallet_address, options)
+        report_util.run_exports(TICKER_DVPN, wallet_address, exporter, export_format)
+
+
+def _read_options(options):
+    report_util.read_common_options(localconfig, options)
+    logging.info("localconfig: %s", localconfig.__dict__)
+
+
+def wallet_exists(wallet_address):
+    return common.ibc.api_lcd.LcdAPI(DVPN_LCD_NODE).account_exists(wallet_address)
+
+
+def txone(wallet_address, txid):
+    elem = common.ibc.api_lcd.LcdAPI(DVPN_LCD_NODE).get_tx(txid)
+
+    print("Transaction data:")
+    pprint.pprint(elem)
+
+    exporter = Exporter(wallet_address, localconfig, TICKER_DVPN)
+    txinfo = dvpn.processor.process_tx(wallet_address, elem, exporter)
+    txinfo.print()
+    return exporter
+
+
+def txhistory(wallet_address, options):
+    # Configure localconfig based on options
+    _read_options(options)
+    if localconfig.cache:
+        localconfig.ibc_addresses = Cache().get_ibc_addresses()
+        logging.info("Loaded ibc_addresses from cache ...")
+
+    max_txs = localconfig.limit
+    progress = ProgressDvpn()
+    exporter = Exporter(wallet_address, localconfig, TICKER_DVPN)
+
+    # LCD - fetch count of transactions to estimate progress more accurately
+    lcd_count_pages = common.ibc.api_lcd.get_txs_pages_count(DVPN_LCD_NODE, wallet_address, max_txs, debug=localconfig.debug)
+    progress.set_lcd_estimate(lcd_count_pages)
+
+    # LCD - fetch transactions
+    lcd_elems = common.ibc.api_lcd.get_txs_all(DVPN_LCD_NODE, wallet_address, progress, max_txs,
+                                               debug=localconfig.debug,
+                                               stage_name="lcd"
+                                               )
+
+    # Some older transaction types can no longer be processed through the latest sentinelhub LCD api (version 0.9.2 at time of writing).
+    # Example failure message:
+    #     "unable to resolve type URL /sentinel.session.v1.MsgService/MsgStart: tx parse error: invalid request"
+    #
+    # Use the RPC api to backfill any transactions that were missing.
+    # Only found cases of this when the address is the sender, so the `events_types` queried are limited.
+
+    # RPC - fetch count of transactions to estimate progress more accurately
+    rpc_count_pages = common.ibc.api_rpc.get_txs_pages_count(DVPN_RPC_NODE, wallet_address, max_txs, debug=localconfig.debug)
+    progress.set_rpc_estimate(rpc_count_pages)
+
+    # RPC - fetch transactions
+    rpc_elems = common.ibc.api_rpc.get_txs_all(DVPN_RPC_NODE, wallet_address, progress, max_txs,
+                                               debug=localconfig.debug,
+                                               stage_name="rpc",
+                                               events_types=[common.ibc.api_common.EVENTS_TYPE_SENDER]
+                                               )
+
+    # See if there were any missing transactions between the LCD and RPC scans
+    lcd_tx_hashes = set([e["txhash"] for e in lcd_elems])
+    rpc_tx_hashes = set([e["hash"] for e in rpc_elems])
+    missing_tx_hashes = frozenset(rpc_tx_hashes.difference(lcd_tx_hashes))
+
+    elems = lcd_elems
+    if missing_tx_hashes:
+        progress.report_message(f"Found {len(missing_tx_hashes)} from RPC api that were missing from the LCD api")
+
+        missing_elems = list(filter(
+            lambda e, hashes=missing_tx_hashes: e["hash"] in hashes,
+            rpc_elems
+        ))
+        common.ibc.api_rpc.normalize_rpc_txns(DVPN_RPC_NODE, missing_elems)
+
+        elems.extend(missing_elems)
+
+    # Process all transactions
+    progress.report_message(f"Processing {len(elems)} transactions... ")
+    dvpn.processor.process_txs(wallet_address, elems, exporter)
+
+    # Calculate payments from escrow to the dVPN node for usage
+    # These payments are kept off-chain and are calculated by looking up all subscriptions,
+    # calculating their used percentage * price, and using the date information
+    # This will not be 100% accurate on timing of payments, but I haven't found a better way yet
+
+    if localconfig.cache:
+        Cache().set_ibc_addresses(localconfig.ibc_addresses)
+
+    return exporter
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/src/settings_csv.py
+++ b/src/settings_csv.py
@@ -6,6 +6,8 @@ ALGO_HIST_INDEXER_NODE = os.environ.get("ALGO_HIST_INDEXER_NODE", "https://index
 ALGO_INDEXER_NODE = os.environ.get("ALGO_INDEXER_NODE", "https://algoindexer.algoexplorerapi.io")
 ATOM_NODE = os.environ.get("ATOM_NODE", "")
 COVALENT_NODE = os.environ.get("COVALENT_NODE", "https://api.covalenthq.com")
+DVPN_LCD_NODE = os.environ.get("DVPN_LCD_NODE", "https://lcd.sentinel.co")
+DVPN_RPC_NODE = os.environ.get("DVPN_RPC_NODE", "https://rpc.sentinel.co")
 FET_NODE = os.environ.get("FET_NODE", "https://rest-fetchhub.fetch.ai")
 
 HUAHUA_NODE = os.environ.get("HUAHUA_NODE", "")
@@ -23,6 +25,7 @@ TERRA_FIGMENT_KEY = os.environ.get("TERRA_FIGMENT_KEY", "")
 
 TICKER_ALGO = "ALGO"
 TICKER_ATOM = "ATOM"
+TICKER_DVPN = "DVPN"
 TICKER_FET = "FET"
 TICKER_HUAHUA = "HUAHUA"
 TICKER_IOTEX = "IOTX"


### PR DESCRIPTION
Adding support for the Sentinel chain (decentralized VPN): https://sentinel.co/.

Has support for:
* Standard transfer and delegation transactions through the common LCD API module
* Sentinel dVPN node management transactions
* Sentinel dVPN subscription transactions (payments from users into escrow)

It does not yet support payments to dVPN node operators (from escrow to node operators) for the reasons mentioned in the comments in `dvpn.processor.process_usage_payments` and this will be tackled in a future PR.

Ran into an issue where the current Sentinel LCD API couldn't process some older transaction types.
This required falling back to the RPC API to backfill any missing transactions.
To support this, added on to `common.ibc.api_rpc` to make  RPC transaction elements look like LCD transaction elements:
* Based on the RPC API implementation in `fet.fetchhub1`
    * Let me know if you would rather this not be in `common.ibc` and I can move it into `dvpn`
    * If it stays in `common.ibc`, `fet.fetchhub1` could be refactored to use the common implementation, but not sure if there is value given fetchhub1 isn't in use now
* Added a generic protobuf decoder that can be used without a .proto definition to extract the fee information from a Cosmos transaction
* Refactored some common elements across `common.ibc.api_lcd` and `common.ibc.api_rpc` into `common.ibc.api_common`

Will send over an email with some example addresses to run against shortly.