### PR TITLE
fix: dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9.9-slim
 
 ENV APPHOME=/staketaxcsv
 
-RUN apt-get update && apt-get install --no-install-recommends -y curl bzip2 \
+RUN apt-get update && apt-get install --no-install-recommends -y curl bzip2 build-essential \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p ${APPHOME}


### PR DESCRIPTION
Adds `build-essential` so that pysha3 can build

```
#10 58.29 Building wheels for collected packages: pysha3
#10 58.30   Building wheel for pysha3 (setup.py): started
#10 59.65   Building wheel for pysha3 (setup.py): finished with status 'error'
#10 59.66   ERROR: Command errored out with exit status 1:
#10 59.66    command: /usr/local/bin/python -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-b31tl9xb/pysha3_c074613d7ec84e4ab0c7c4e6d186edfa/setup.py'"'"'; __file__='"'"'/tmp/pip-install-b31tl9xb/pysha3_c074613d7ec84e4ab0c7c4e6d186edfa/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-241w0ps6
#10 59.66        cwd: /tmp/pip-install-b31tl9xb/pysha3_c074613d7ec84e4ab0c7c4e6d186edfa/
#10 59.66   Complete output (13 lines):
#10 59.66   running bdist_wheel
#10 59.66   running build
#10 59.66   running build_py
#10 59.66   creating build
#10 59.66   creating build/lib.linux-x86_64-3.9
#10 59.66   copying sha3.py -> build/lib.linux-x86_64-3.9
#10 59.66   running build_ext
#10 59.66   building '_pysha3' extension
#10 59.66   creating build/temp.linux-x86_64-3.9
#10 59.66   creating build/temp.linux-x86_64-3.9/Modules
#10 59.66   creating build/temp.linux-x86_64-3.9/Modules/_sha3
#10 59.66   gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DPY_WITH_KECCAK=1 -I/usr/local/include/python3.9 -c Modules/_sha3/sha3module.c -o build/temp.linux-x86_64-3.9/Modules/_sha3/sha3module.o
#10 59.66   error: command 'gcc' failed: No such file or directory
#10 59.66   ----------------------------------------
#10 59.66   ERROR: Failed building wheel for pysha3
#10 59.66   Running setup.py clean for pysha3
#10 60.75 Failed to build pysha3
#10 61.82 Installing collected packages: six, urllib3, python-dateutil, pycparser, jmespath, cffi, botocore, s3transfer, pytz, pynacl, pycryptodomex, numpy, msgpack, idna, et-xmlfile, charset-normalizer, certifi, tabulate, requests, PyYAML, pysha3, pycodestyle, py-algorand-sdk, pandas, openpyxl, mock, isort, boto3, bech32, base58
#10 82.69     Running setup.py install for pysha3: started
#10 83.90     Running setup.py install for pysha3: finished with status 'error'
#10 83.90     ERROR: Command errored out with exit status 1:
#10 83.90      command: /usr/local/bin/python -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-b31tl9xb/pysha3_c074613d7ec84e4ab0c7c4e6d186edfa/setup.py'"'"'; __file__='"'"'/tmp/pip-install-b31tl9xb/pysha3_c074613d7ec84e4ab0c7c4e6d186edfa/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-xw8s7_m4/install-record.txt --single-version-externally-managed --compile --install-headers /usr/local/include/python3.9/pysha3
#10 83.90          cwd: /tmp/pip-install-b31tl9xb/pysha3_c074613d7ec84e4ab0c7c4e6d186edfa/
#10 83.90     Complete output (13 lines):
#10 83.90     running install
#10 83.90     running build
#10 83.90     running build_py
#10 83.90     creating build
#10 83.90     creating build/lib.linux-x86_64-3.9
#10 83.90     copying sha3.py -> build/lib.linux-x86_64-3.9
#10 83.90     running build_ext
#10 83.90     building '_pysha3' extension
#10 83.90     creating build/temp.linux-x86_64-3.9
#10 83.90     creating build/temp.linux-x86_64-3.9/Modules
#10 83.90     creating build/temp.linux-x86_64-3.9/Modules/_sha3
#10 83.90     gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DPY_WITH_KECCAK=1 -I/usr/local/include/python3.9 -c Modules/_sha3/sha3module.c -o build/temp.linux-x86_64-3.9/Modules/_sha3/sha3module.o
#10 83.90     error: command 'gcc' failed: No such file or directory
#10 83.90     ----------------------------------------
#10 83.90 ERROR: Command errored out with exit status 1: /usr/local/bin/python -u -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-b31tl9xb/pysha3_c074613d7ec84e4ab0c7c4e6d186edfa/setup.py'"'"'; __file__='"'"'/tmp/pip-install-b31tl9xb/pysha3_c074613d7ec84e4ab0c7c4e6d186edfa/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-xw8s7_m4/install-record.txt --single-version-externally-managed --compile --install-headers /usr/local/include/python3.9/pysha3 Check the logs for full command output.
#10 84.79 WARNING: You are using pip version 21.2.4; however, version 22.3 is available.
#10 84.79 You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.

```