### PR TITLE
fix: use 2 instead of ORDER_BY_DESC for txs queries

### DIFF
--- a/src/staketaxcsv/atom/api_lcd.py
+++ b/src/staketaxcsv/atom/api_lcd.py
@@ -46,7 +46,7 @@ def account_exists(wallet_address):
 def _get_txs(wallet_address, is_sender, offset, sleep_seconds):
     uri_path = "/cosmos/tx/v1beta1/txs"
     query_params = {
-        "order_by": "2",
+        "order_by": 2,
         "pagination.limit": LIMIT_PER_QUERY,
         "pagination.offset": offset,
         "pagination.count_total": True,

--- a/src/staketaxcsv/atom/api_lcd.py
+++ b/src/staketaxcsv/atom/api_lcd.py
@@ -46,7 +46,7 @@ def account_exists(wallet_address):
 def _get_txs(wallet_address, is_sender, offset, sleep_seconds):
     uri_path = "/cosmos/tx/v1beta1/txs"
     query_params = {
-        "order_by": "ORDER_BY_DESC",
+        "order_by": "2",
         "pagination.limit": LIMIT_PER_QUERY,
         "pagination.offset": offset,
         "pagination.count_total": True,

--- a/src/staketaxcsv/common/ibc/api_lcd.py
+++ b/src/staketaxcsv/common/ibc/api_lcd.py
@@ -57,7 +57,7 @@ class LcdAPI:
             "pagination.limit": limit,
             "pagination.offset": offset,
             "pagination.count_total": True,
-            "order_by": "ORDER_BY_DESC",
+            "order_by": "2",
         }
 
         if events_type == EVENTS_TYPE_SENDER:

--- a/src/staketaxcsv/common/ibc/api_lcd.py
+++ b/src/staketaxcsv/common/ibc/api_lcd.py
@@ -57,7 +57,7 @@ class LcdAPI:
             "pagination.limit": limit,
             "pagination.offset": offset,
             "pagination.count_total": True,
-            "order_by": "2",
+            "order_by": 2,
         }
 
         if events_type == EVENTS_TYPE_SENDER:
@@ -83,7 +83,7 @@ class LcdAPI:
         elems = data["tx_responses"]
         next_offset = offset + limit if len(elems) == limit else None
 
-        if wallet_address.startswith("evmos"):
+        if data["pagination"] is None:
             total_count_txs = int(data["total"])
         else:
             total_count_txs = int(data["pagination"]["total"])

--- a/src/staketaxcsv/luna1/api_lcd.py
+++ b/src/staketaxcsv/luna1/api_lcd.py
@@ -38,7 +38,7 @@ class LcdAPI:
     def _get_txs(cls, wallet_address, events_type, offset, limit, sleep_seconds):
         uri_path = "/cosmos/tx/v1beta1/txs"
         query_params = {
-            "order_by": "2",
+            "order_by": 2,
             "pagination.limit": limit,
             "pagination.offset": offset,
             "pagination.count_total": True,

--- a/src/staketaxcsv/luna1/api_lcd.py
+++ b/src/staketaxcsv/luna1/api_lcd.py
@@ -38,7 +38,7 @@ class LcdAPI:
     def _get_txs(cls, wallet_address, events_type, offset, limit, sleep_seconds):
         uri_path = "/cosmos/tx/v1beta1/txs"
         query_params = {
-            "order_by": "ORDER_BY_DESC",
+            "order_by": "2",
             "pagination.limit": limit,
             "pagination.offset": offset,
             "pagination.count_total": True,


### PR DESCRIPTION
I believe these fixes are needed to make v0.46.x chains work (maybe with the exception of evmos given the existing handling)

closes: #264 
closes: #266

Should be backwards compatible:
> https://lcd.cosmos.dragonstake.io/cosmos/tx/v1beta1/txs?order_by=2&pagination.limit=50&pagination.offset=0&pagination.count_total=True&events=message.sender%3D%27cosmos1whegdpjda0hta5s4h6k45yu4p8k2l2w6mxm5yd%27

(using random address and v0.45.x chain)

Are there tests that can be run?