### PR TITLE
[Juno] Fix crash when no action present in event logs

### DIFF
--- a/src/staketaxcsv/common/ibc/MsgInfoIBC.py
+++ b/src/staketaxcsv/common/ibc/MsgInfoIBC.py
@@ -42,8 +42,7 @@ class MsgInfoIBC:
             last_field = message["type"].split("/")[-1]
         else:
             # raise Exception("Unexpected message: {}".format(message))
-            logging.warning("Skipping unexpected message: %s", message)
-            last_field = "Message"
+            last_field = None
         return last_field
 
     def _has_coin_spent_received(self):

--- a/src/staketaxcsv/common/ibc/MsgInfoIBC.py
+++ b/src/staketaxcsv/common/ibc/MsgInfoIBC.py
@@ -41,7 +41,9 @@ class MsgInfoIBC:
             # luna2 only: staking/MsgUndelegate -> MsgUndelegate
             last_field = message["type"].split("/")[-1]
         else:
-            raise Exception("Unexpected message: {}".format(message))
+            # raise Exception("Unexpected message: {}".format(message))
+            logging.warning("Skipping unexpected message: %s", message)
+            last_field = "Message"
         return last_field
 
     def _has_coin_spent_received(self):

--- a/src/staketaxcsv/common/ibc/api_rpc.py
+++ b/src/staketaxcsv/common/ibc/api_rpc.py
@@ -276,7 +276,8 @@ def _make_message_from_event_attributes(event_attributes):
     #
     # note: we do not do any other combination of events to produce application
     # specific message fields and rely on transfer events to dictate any movement of coins
-    message["@type"] = message["action"]
-    del message["action"]
+    if message.get("action") != None:
+        message["@type"] = message["action"]
+        del message["action"]
 
     return message

--- a/src/staketaxcsv/common/ibc/api_rpc.py
+++ b/src/staketaxcsv/common/ibc/api_rpc.py
@@ -257,8 +257,11 @@ def _add_messages_from_logs(elem):
             if event_type != "message":
                 continue
 
-            message = _make_message_from_event_attributes(event_attributes)
-            messages.append(message)
+            try:
+                message = _make_message_from_event_attributes(event_attributes)
+                messages.append(message)
+            except Exception as e:
+                logging.error("Unexpected message for txid=%s, exception=%s", elem["txhash"], str(e))
 
     # add messages into the transaction body element
     elem["tx"]["body"] = {
@@ -279,5 +282,7 @@ def _make_message_from_event_attributes(event_attributes):
     if message.get("action") != None:
         message["@type"] = message["action"]
         del message["action"]
+        return message
+    else:
+        raise Exception("Unexpected message: {}".format(message))
 
-    return message

--- a/src/staketaxcsv/common/ibc/processor.py
+++ b/src/staketaxcsv/common/ibc/processor.py
@@ -34,11 +34,14 @@ def txinfo(wallet_address, elem, mintscan_label, ibc_addresses, lcd_node, custom
         message = elem["tx"]["body"]["messages"][i]
         log = elem["logs"][i]
 
-        if customMsgInfo:
-            msginfo = customMsgInfo(wallet_address, i, message, log, lcd_node, ibc_addresses)
-        else:
-            msginfo = MsgInfoIBC(wallet_address, i, message, log, lcd_node, ibc_addresses)
-        msgs.append(msginfo)
+        try:
+            if customMsgInfo:
+                msginfo = customMsgInfo(wallet_address, i, message, log, lcd_node, ibc_addresses)
+            else:
+                msginfo = MsgInfoIBC(wallet_address, i, message, log, lcd_node, ibc_addresses)
+            msgs.append(msginfo)
+        except Exception as e:
+            logging.error("Exception when creating MsgInfoIBC object. exception=%s, txid=%s, message=%s", str(e), txid, message)
 
     txinfo = TxInfoIBC(txid, timestamp, fee, fee_currency, wallet_address, msgs, mintscan_label, memo, is_failed)
     return txinfo


### PR DESCRIPTION
It appears that some Juno transaction event logs don't include an action (for whatever reason), which causes the report to crash.