### PR TITLE
fix: BLD transaction link

### DIFF
--- a/src/staketaxcsv/bld/processor.py
+++ b/src/staketaxcsv/bld/processor.py
@@ -14,7 +14,7 @@ def process_txs(wallet_address, elems, exporter):
 
 def process_tx(wallet_address, elem, exporter):
     txinfo = staketaxcsv.common.ibc.processor.txinfo(wallet_address, elem, co.MINTSCAN_LABEL_BLD, BLD_NODE)
-    txinfo.url = "https://agoric.bigdipper.live/transactions/{}".format(txinfo.txid)
+    txinfo.url = "https://www.mintscan.io/agoric/tx/{}".format(txinfo.txid)
 
     if txinfo.is_failed:
         staketaxcsv.common.ibc.processor.handle_failed_transaction(exporter, txinfo)


### PR DESCRIPTION
https://agoric.bigdipper.live/ is out of service. Link to Mintscan instead.